### PR TITLE
Add issue template for bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -1,0 +1,32 @@
+---
+name: 🐛 Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: 'bug, untriaged, Beta'
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Relevant infra configuration (please complete the following information):**
+ - [e.g AMI ID...]
+ - [e.g OpenSearch distribution link...]
+ - [e.g security config...]
+ - [e.g plugins enabled]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Signed-off-by: Abbas Hussain <abbas_10690@yahoo.com>

### Description
Adds a template to create issue for any bugs.
 
### Issues Resolved
#2 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
