### PR TITLE
Correct copyright notices to reflect Copyright OpenSearch Contributors

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,1 +1,2 @@
-Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+OpenSearch (https://opensearch.org/)
+Copyright OpenSearch Contributors

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ This project is licensed under the Apache-2.0 License.
 
 ## Copyright
 
-Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright OpenSearch Contributors. See [NOTICE](NOTICE.txt) for details.


### PR DESCRIPTION
Signed-off-by: Abbas Hussain <abbas_10690@yahoo.com>

### Description
- Removed Amazon copyright, the correct copyright for OpenSearch projects is "Copyright OpenSearch Contributors".
- Fixed copyright in NOTICE and linked it from README.

### Issues Resolved
#25 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/project-website-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).