### PR TITLE
updating maintainers and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/project-website-search
+*   @CEHENKLE @dblock @setiah @kartg @nknize @adnapibar @tlfeng @VachaShah @AMoo-Miki @ashwin-pc @saratvemulapalli

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,27 @@
+- [Current Maintainers](#current-maintainers)
+- [Emeritus](#emeritus)
+
+## Current Maintainers
+
+| Maintainer | GitHub ID | Affiliation |
+| --------------- | --------- | ----------- |
+| Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE) | Amazon |
+| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock) | Amazon |
+| Himanshu Setia | [setiah](https://github.com/setiah) | Amazon |
+| Kartik Ganesh | [kartg](https://github.com/kartg) | Amazon |
+| Nick Knize | [nknize](https://github.com/nknize) | Amazon |
+| Rabi Panda | [adnapibar](https://github.com/adnapibar) | Amazon |
+| Tianli Feng | [tlfeng](https://github.com/tlfeng) | Amazon |
+| Vacha Shah | [VachaShah](https://github.com/VachaShah) | Amazon |
+| Miki Barahmand | [AMoo-Miki](https://github.com/AMoo-Miki) | Amazon |
+| Ashwin P Chandran | [ashwin-pc](https://github.com/ashwin-pc) | Amazon |
+| Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon |
+
+
+## Emeritus
+
+| Maintainer | GitHub ID | Affiliation |
+| --------------- | --------- | ----------- |
+| Abbas Hussain | [abbashus](https://github.com/abbashus) | Amazon |
+
+[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Signed-off-by: CEHENKLE <henkle@amazon.com>

### Description
Makes sure our maintainers.md and code owners files match current permissions

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/project-website-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).