### PR TITLE
Move dblock to emeritus maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @AMoo-Miki @dblock @macohen
+*   @AMoo-Miki @macohen

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,11 +4,10 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer               | GitHub ID                                               | Affiliation |
-|--------------------------|---------------------------------------------------------|-------------|
-| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)                     | Amazon      |
-| Miki Barahmand           | [AMoo-Miki](https://github.com/AMoo-Miki)               | Amazon      |
-| Mark Cohen               | [macohen](https://github.com/macohen)                   | Amazon      |
+| Maintainer     | GitHub ID                                 | Affiliation |
+|----------------|-------------------------------------------|-------------|
+| Miki Barahmand | [AMoo-Miki](https://github.com/AMoo-Miki) | Amazon      |
+| Mark Cohen     | [macohen](https://github.com/macohen)     | Amazon      |
 
 
 ## Emeritus
@@ -17,6 +16,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 |--------------------------|---------------------------------------------------------|-------------|
 | Abbas Hussain            | [abbashus](https://github.com/abbashus)                 | Amazon      |
 | Charlotte Henkle         | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |
+| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)                     | Independent |
 | Himanshu Setia           | [setiah](https://github.com/setiah)                     | Amazon      |
 | Kartik Ganesh            | [kartg](https://github.com/kartg)                       | Amazon      |
 | Nick Knize               | [nknize](https://github.com/nknize)                     | Amazon      |


### PR DESCRIPTION
## Summary
- Moved dblock to emeritus maintainers section
- Removed dblock from CODEOWNERS

🤖 Generated with [Claude Code](https://claude.com/claude-code)